### PR TITLE
DO-137 Correct the cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
 
 ## Unreleased
+### Changed
+- [DO-137] Correct the cache key
+
 ### Added
 - [TT-1392] Changelog file

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -19,6 +19,7 @@ class Cache
       trip_routes
       properties
       geocode
+      resource
     )
   end
 
@@ -27,6 +28,6 @@ class Cache
   end
 
   def self.clear_other
-    other_types.each { |key| QuickTravel::Cache.cache_store.delete_matched /#{key}_*/ }
+    other_types.each { |key| QuickTravel::Cache.cache_store.delete_matched "#{key}_*" }
   end
 end


### PR DESCRIPTION
# Why?

I think `delete_matched` does not support RegEx, and even if it does, it should be `/#{key}_.*/` instead of `/#{key}_*/`.

# Testing

Tested in our testing stack.